### PR TITLE
Fix config of mail_from_name and mail_smtp_auth

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,12 +114,12 @@ sed -i -e "s|\$use_tokens.*|\$use_tokens = $USE_TOKENS;|g" /usr/share/self-servi
 sed -i -e "s|\$crypt_tokens.*|\$crypt_tokens = $CRYPT_TOKENS;|g" /usr/share/self-service-password/conf/config.inc.php
 
 sed -i -e "s|\$mail_address_use_ldap.*|\$mail_address_use_ldap = $MAIL_ADDRESS_USE_LDAP;|g" /usr/share/self-service-password/conf/config.inc.php
-sed -i -e "s|\$mail_from.*|\$mail_from = \"$MAIL_FROM\";|g" /usr/share/self-service-password/conf/config.inc.php
+sed -i -e "s|\$mail_from =.*|\$mail_from = \"$MAIL_FROM\";|g" /usr/share/self-service-password/conf/config.inc.php
 sed -i -e "s|\$mail_from_name.*|\$mail_from_name = \"$MAIL_FROM_NAME\";|g" /usr/share/self-service-password/conf/config.inc.php
 sed -i -e "s|\$mail_sendmailpath.*|\$mail_sendmailpath = \"$MAIL_SENDMAILPATH\";|g" /usr/share/self-service-password/conf/config.inc.php
 sed -i -e "s|\$mail_smtp_debug.*|\$mail_smtp_debug = $MAIL_SMTP_DEBUG;|g" /usr/share/self-service-password/conf/config.inc.php
 sed -i -e "s|\$mail_smtp_host.*|\$mail_smtp_host = \"$MAIL_SMTP_HOST\";|g" /usr/share/self-service-password/conf/config.inc.php
-sed -i -e "s|\$mail_smtp_auth.*|\$mail_smtp_auth = \"$MAIL_SMTP_AUTH\";|g" /usr/share/self-service-password/conf/config.inc.php
+sed -i -e "s|\$mail_smtp_auth.*|\$mail_smtp_auth = $MAIL_SMTP_AUTH;|g" /usr/share/self-service-password/conf/config.inc.php
 sed -i -e "s|\$mail_smtp_user.*|\$mail_smtp_user = \"$MAIL_SMTP_USER\";|g" /usr/share/self-service-password/conf/config.inc.php
 sed -i -e "s|\$mail_smtp_pass.*|\$mail_smtp_pass = \"$MAIL_SMTP_PASS\";|g" /usr/share/self-service-password/conf/config.inc.php
 sed -i -e "s|\$mail_smtp_port.*|\$mail_smtp_port = $MAIL_SMTP_PORT;|g" /usr/share/self-service-password/conf/config.inc.php


### PR DESCRIPTION
Fixes these issues:
1. mail_smtp_auth is currently set as a string value, e.g. `$mail_smtp_auth = "false"` instead of `$mail_smtp_auth = false`. This results in SMTP authentication always being active.
2. mail_from_name is not present in modified config.inc.php, instead `$mail_from = ...` appears twice